### PR TITLE
refactor: genericise the package and bump to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The code for this example would look something like:
 
 ```go
 // Initialize the graph.
-graph := topsort.NewGraph()
+graph := topsort.NewGraph[string]()
 
 // Add edges.
 graph.AddEdge("A", "B")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/stevenle/topsort
+module github.com/stevenle/topsort/v2
 
-go 1.16
+go 1.18

--- a/topsort.go
+++ b/topsort.go
@@ -51,14 +51,14 @@ func (g *Graph[Key]) AddEdge(from Key, to Key) error {
 	return nil
 }
 
-func (g *Graph[Key]) ContainsNode(name Key) bool {
-	_, ok := g.nodes[name]
+func (g *Graph[Key]) ContainsNode(key Key) bool {
+	_, ok := g.nodes[key]
 	return ok
 }
 
-func (g *Graph[Key]) TopSort(name Key) ([]Key, error) {
+func (g *Graph[Key]) TopSort(key Key) ([]Key, error) {
 	results := newOrderedSet[Key]()
-	err := g.visit(name, results, nil)
+	err := g.visit(key, results, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +95,8 @@ func (g *Graph[Key]) visit(key Key, results *orderedset[Key], visited *orderedse
 
 type nodeimpl[Key comparable] map[Key]bool
 
-func (n nodeimpl[Key]) addEdge(name Key) {
-	n[name] = true
+func (n nodeimpl[Key]) addEdge(key Key) {
+	n[key] = true
 }
 
 func (n nodeimpl[Key]) edges() []Key {

--- a/topsort_test.go
+++ b/topsort_test.go
@@ -144,7 +144,7 @@ func TestTopSortCycleError3(t *testing.T) {
 	}
 }
 
-func initGraph() *Graph {
-	graph := NewGraph()
+func initGraph() *Graph[string] {
+	graph := NewGraph[string]()
 	return graph
 }


### PR DESCRIPTION
Switch to generics to allow non-string types to be topologically sorted.

Bumped to v2 because this is a backwards-incompatible change.